### PR TITLE
Include Front SDK to prevent undefined Front error

### DIFF
--- a/dm-assistant.html
+++ b/dm-assistant.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>DM Assistant</title>
+    <script src="https://unpkg.com/@frontapp/plugin-sdk@1.12.0/dist/sdk.min.js"></script>
     <style>
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;


### PR DESCRIPTION
## Summary
- load Front plugin SDK in `dm-assistant.html` so the `Front` object is defined when generating responses

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897966b99288325a22584686c60d569